### PR TITLE
Newer golang to fix wireguard-go compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Prepare wireguard-go in separate builder
-ARG GOLANG_VERSION=1.18.0
-ARG ALPINE_VERSION=3.15
+ARG GOLANG_VERSION=1.20.1
+ARG ALPINE_VERSION=3.17
 ARG wg_go_tag=0.0.20220316
 ARG wg_tools_tag=v1.0.20210914
 


### PR DESCRIPTION
Fix errors
```
#0 9.889 device/peer.go:19:27: undefined: atomic.Bool
#0 9.889 device/peer.go:26:27: undefined: atomic.Uint64
#0 9.889 device/peer.go:27:27: undefined: atomic.Uint64
#0 9.889 device/peer.go:28:27: undefined: atomic.Int64
#0 9.889 device/keypair.go:25:22: undefined: atomic.Uint64
#0 9.889 device/keypair.go:39:18: undefined: atomic.Pointer
#0 9.889 device/device.go:33:16: undefined: atomic.Uint32
#0 9.889 device/device.go:62:25: undefined: atomic.Int64
#0 9.889 device/device.go:84:17: undefined: atomic.Int32
#0 9.889 device/pools.go:17:15: undefined: atomic.Uint32
```
within `make` process of wireguard-go while building docker image.

<details><summary>Full error</summary>
<pre>
$ sudo docker build --tag wg-easy .
[+] Building 57.1s (13/19)                                                                                                                                                                                  
 => [internal] load build definition from Dockerfile                                                                                                                                                   0.0s
 => => transferring dockerfile: 1.99kB                                                                                                                                                                 0.0s
 => [internal] load .dockerignore                                                                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                                                                        0.0s
 => [internal] load metadata for docker.io/library/node:14-alpine@sha256:dc92f36e7cd917816fa2df041d4e9081453366381a00f40398d99e9392e78664                                                              2.1s
 => [internal] load metadata for docker.io/library/golang:1.18.0-alpine3.15                                                                                                                            3.7s
 => [internal] load build context                                                                                                                                                                      0.0s
 => => transferring context: 10.55kB                                                                                                                                                                   0.0s
 => CACHED [build_node_modules 1/4] FROM docker.io/library/node:14-alpine@sha256:dc92f36e7cd917816fa2df041d4e9081453366381a00f40398d99e9392e78664                                                      0.0s
 => [wireguard-go 1/4] FROM docker.io/library/golang:1.18.0-alpine3.15@sha256:a2ca4f4c0828b1b426a3153b068bf32a21868911c57a9fc4dccdc5fbb6553b35                                                        20.2s
 => => resolve docker.io/library/golang:1.18.0-alpine3.15@sha256:a2ca4f4c0828b1b426a3153b068bf32a21868911c57a9fc4dccdc5fbb6553b35                                                                      0.0s
 => => sha256:a2ca4f4c0828b1b426a3153b068bf32a21868911c57a9fc4dccdc5fbb6553b35 1.65kB / 1.65kB                                                                                                         0.0s
 => => sha256:7473adb02bd430045c938f61e2c2177ff62b28968579dfed99085a0960f76f5d 1.36kB / 1.36kB                                                                                                         0.0s
 => => sha256:c04fbda3c7471a7bc6f9057295058a5c55c5c21e51680007085bdb4ff2dfb2dd 5.55kB / 5.55kB                                                                                                         0.0s
 => => sha256:df9b9388f04ad6279a7410b85cedfdcb2208c0a003da7ab5613af71079148139 2.81MB / 2.81MB                                                                                                         0.8s
 => => sha256:52dc419b0ee22d1bb5f3b95a57b2edc733b7b585277f8101db7b2c9b53605c1b 271.96kB / 271.96kB                                                                                                     0.5s
 => => sha256:25bc292e5bacdd8b97a1632a82d0fd0ee6c2692409bd4b35cb9e7e652efbc7c8 153B / 153B                                                                                                             0.5s
 => => sha256:52f612e3e4f463a55ae1b4bd0e11708632139faaa966492fb1154caa16c99d2e 115.56MB / 115.56MB                                                                                                    14.6s
 => => sha256:0877cc8fb293f97b8ab18ec3ff2afd35d67c7c1346457b6ae1a4679a71302e04 156B / 156B                                                                                                             1.1s
 => => extracting sha256:df9b9388f04ad6279a7410b85cedfdcb2208c0a003da7ab5613af71079148139                                                                                                              0.2s
 => => extracting sha256:52dc419b0ee22d1bb5f3b95a57b2edc733b7b585277f8101db7b2c9b53605c1b                                                                                                              0.1s
 => => extracting sha256:25bc292e5bacdd8b97a1632a82d0fd0ee6c2692409bd4b35cb9e7e652efbc7c8                                                                                                              0.0s
 => => extracting sha256:52f612e3e4f463a55ae1b4bd0e11708632139faaa966492fb1154caa16c99d2e                                                                                                              4.9s
 => => extracting sha256:0877cc8fb293f97b8ab18ec3ff2afd35d67c7c1346457b6ae1a4679a71302e04                                                                                                              0.0s
 => [build_node_modules 2/4] COPY src/ /app/                                                                                                                                                           0.1s
 => [build_node_modules 3/4] WORKDIR /app                                                                                                                                                              0.0s 
 => [build_node_modules 4/4] RUN npm ci --production                                                                                                                                                   5.4s
 => [stage-2 2/7] COPY --from=build_node_modules /app /app                                                                                                                                             0.3s
 => [wireguard-go 2/4] RUN apk add --update git build-base libmnl-dev iptables                                                                                                                        23.1s
 => ERROR [wireguard-go 3/4] RUN git clone https://git.zx2c4.com/wireguard-go &&   cd wireguard-go &&   git checkout $wg_go_tag &&   make &&   make install                                           10.0s 
------                                                                                                                                                                                                      
 > [wireguard-go 3/4] RUN git clone https://git.zx2c4.com/wireguard-go &&   cd wireguard-go &&   git checkout $wg_go_tag &&   make &&   make install:                                                       
#0 0.683 Cloning into 'wireguard-go'...                                                                                                                                                                     
#0 5.172 Your branch is up to date with 'origin/master'.                                                                                                                                                    
#0 5.241 go build -v -o "wireguard-go"                                                                                                                                                                      
#0 5.254 go: downloading golang.org/x/sys v0.2.0                                                                                                                                                            
#0 5.259 go: downloading golang.org/x/net v0.0.0-20220225172249-27dd8689420f
#0 5.285 go: downloading golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd
#0 7.468 golang.org/x/crypto/internal/subtle
#0 7.471 golang.zx2c4.com/wireguard/replay
#0 7.471 golang.org/x/net/internal/iana
#0 7.524 golang.org/x/sys/cpu
#0 7.525 golang.org/x/sys/unix
#0 7.526 golang.org/x/crypto/chacha20
#0 7.541 golang.org/x/crypto/internal/poly1305
#0 7.733 golang.org/x/crypto/curve25519/internal/field
#0 7.777 golang.org/x/crypto/blake2s
#0 7.805 golang.org/x/crypto/chacha20poly1305
#0 8.044 golang.org/x/crypto/curve25519
#0 8.076 golang.org/x/crypto/poly1305
#0 8.113 golang.org/x/net/bpf
#0 8.138 golang.zx2c4.com/wireguard/ratelimiter
#0 8.144 golang.zx2c4.com/wireguard/tai64n
#0 8.861 golang.zx2c4.com/wireguard/conn
#0 8.862 golang.org/x/net/internal/socket
#0 8.863 golang.zx2c4.com/wireguard/rwcancel
#0 9.050 golang.zx2c4.com/wireguard/ipc
#0 9.218 golang.org/x/net/ipv4
#0 9.225 golang.org/x/net/ipv6
#0 9.679 golang.zx2c4.com/wireguard/tun
#0 9.817 golang.zx2c4.com/wireguard/device
#0 9.889 # golang.zx2c4.com/wireguard/device
#0 9.889 device/peer.go:19:27: undefined: atomic.Bool
#0 9.889 device/peer.go:26:27: undefined: atomic.Uint64
#0 9.889 device/peer.go:27:27: undefined: atomic.Uint64
#0 9.889 device/peer.go:28:27: undefined: atomic.Int64
#0 9.889 device/keypair.go:25:22: undefined: atomic.Uint64
#0 9.889 device/keypair.go:39:18: undefined: atomic.Pointer
#0 9.889 device/device.go:33:16: undefined: atomic.Uint32
#0 9.889 device/device.go:62:25: undefined: atomic.Int64
#0 9.889 device/device.go:84:17: undefined: atomic.Int32
#0 9.889 device/pools.go:17:15: undefined: atomic.Uint32
#0 9.889 device/peer.go:28:27: too many errors
#0 9.889 note: module requires Go 1.19
#0 9.912 make[1]: *** [Makefile:20: wireguard-go] Error 2
#0 9.912 make: *** [Makefile:12: generate-version-and-build] Error 2
------
Dockerfile:11
--------------------
  10 |     
  11 | >>> RUN git clone https://git.zx2c4.com/wireguard-go && \
  12 | >>>   cd wireguard-go && \
  13 | >>>   git checkout $wg_go_tag && \
  14 | >>>   make && \
  15 | >>>   make install
  16 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c git clone https://git.zx2c4.com/wireguard-go &&   cd wireguard-go &&   git checkout $wg_go_tag &&   make &&   make install" did not complete successfully: exit code: 2
</pre>
</details>

<details><summary>After fix</summary>
<pre>
$ sudo docker build --tag wg-easy .
[+] Building 83.9s (20/20) FINISHED                                                                                                                                                                         
 => [internal] load .dockerignore                                                                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                                                                        0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                                   0.0s
 => => transferring dockerfile: 1.99kB                                                                                                                                                                 0.0s
 => [internal] load metadata for docker.io/library/golang:1.20.1-alpine3.17                                                                                                                            3.3s
 => [internal] load metadata for docker.io/library/node:14-alpine@sha256:dc92f36e7cd917816fa2df041d4e9081453366381a00f40398d99e9392e78664                                                              0.0s
 => [internal] load build context                                                                                                                                                                      0.0s
 => => transferring context: 1.23kB                                                                                                                                                                    0.0s
 => [wireguard-go 1/4] FROM docker.io/library/golang:1.20.1-alpine3.17@sha256:48f336ef8366b9d6246293e3047259d0f614ee167db1869bdbc343d6e09aed8a                                                        17.1s
 => => resolve docker.io/library/golang:1.20.1-alpine3.17@sha256:48f336ef8366b9d6246293e3047259d0f614ee167db1869bdbc343d6e09aed8a                                                                      0.0s
 => => sha256:a2d21d5440ebff5aaaaeb115a003f7a4a3897f1866a87de95bc4a21436fc563c 284.82kB / 284.82kB                                                                                                     0.5s
 => => sha256:752c438cb1864d6b2151010a811031b48f0c3511c7aa49f540322590991c949d 100.63MB / 100.63MB                                                                                                    12.1s
 => => sha256:48f336ef8366b9d6246293e3047259d0f614ee167db1869bdbc343d6e09aed8a 1.65kB / 1.65kB                                                                                                         0.0s
 => => sha256:18da4399cedd9e383beb6b104d43aa1d48bd41167e312bb5306d72c51bd11548 1.16kB / 1.16kB                                                                                                         0.0s
 => => sha256:0b94e5e3eec1be96be80bab3ffc3186af109233342f79fb5051b45ba4beb6bd5 5.11kB / 5.11kB                                                                                                         0.0s
 => => sha256:63b65145d645c1250c391b2d16ebe53b3747c295ca8ba2fcb6b0cf064a4dc21c 3.37MB / 3.37MB                                                                                                         3.2s
 => => sha256:07244a03b3147bcdf5c1256e62110d50e31af7af76ef53aae3bcc9da8410dcdc 155B / 155B                                                                                                             0.9s
 => => extracting sha256:63b65145d645c1250c391b2d16ebe53b3747c295ca8ba2fcb6b0cf064a4dc21c                                                                                                              0.2s
 => => extracting sha256:a2d21d5440ebff5aaaaeb115a003f7a4a3897f1866a87de95bc4a21436fc563c                                                                                                              0.1s
 => => extracting sha256:752c438cb1864d6b2151010a811031b48f0c3511c7aa49f540322590991c949d                                                                                                              4.4s
 => => extracting sha256:07244a03b3147bcdf5c1256e62110d50e31af7af76ef53aae3bcc9da8410dcdc                                                                                                              0.0s
 => [build_node_modules 1/4] FROM docker.io/library/node:14-alpine@sha256:dc92f36e7cd917816fa2df041d4e9081453366381a00f40398d99e9392e78664                                                             0.0s
 => CACHED [build_node_modules 2/4] COPY src/ /app/                                                                                                                                                    0.0s
 => CACHED [build_node_modules 3/4] WORKDIR /app                                                                                                                                                       0.0s
 => CACHED [build_node_modules 4/4] RUN npm ci --production                                                                                                                                            0.0s
 => CACHED [stage-2 2/7] COPY --from=build_node_modules /app /app                                                                                                                                      0.0s
 => [wireguard-go 2/4] RUN apk add --update git build-base libmnl-dev iptables                                                                                                                        17.1s
 => [wireguard-go 3/4] RUN git clone https://git.zx2c4.com/wireguard-go &&   cd wireguard-go &&   git checkout $wg_go_tag &&   make &&   make install                                                 26.9s
 => [wireguard-go 4/4] RUN git clone https://git.zx2c4.com/wireguard-tools &&   cd wireguard-tools &&   git checkout $wg_tools_tag &&   cd src &&   make &&   make install                             8.8s 
 => [stage-2 3/7] COPY --from=wireguard-go /usr/bin/wg /usr/bin/wg-quick /usr/bin/wireguard-go /wireguard-go/                                                                                          0.1s 
 => [stage-2 4/7] RUN mv /app/node_modules /node_modules                                                                                                                                               0.8s 
 => [stage-2 5/7] RUN npm i -g nodemon                                                                                                                                                                 6.4s 
 => [stage-2 6/7] RUN apk add -U --no-cache   wireguard-tools   dumb-init                                                                                                                              2.7s 
 => [stage-2 7/7] WORKDIR /app                                                                                                                                                                         0.0s 
 => exporting to image                                                                                                                                                                                 0.5s 
 => => exporting layers                                                                                                                                                                                0.5s
 => => writing image sha256:3dd77c12b3be3685584779039e159c80695c86dccf460d51f8765b18173dd929                                                                                                           0.0s 
 => => naming to docker.io/library/wg-easy      
</pre>
</details>